### PR TITLE
Skip over BUILDINFO files

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 #include "gzip.h"
 #include "md5.h"
 #include "mtree.h"
+#include "string.h"
 
 
 static const char * default_root      = "/";
@@ -30,6 +31,13 @@ static const char * default_ignores[] = {
 	"/var/log/*",
 	"/var/spool/*",
 	"/var/tmp/*"
+};
+static const char * skip[] = {
+	"/.PKGINFO",
+	"/.INSTALL",
+	"/.CHANGELOG",
+	"/.BUILDINFO",
+	NULL
 };
 
 
@@ -346,7 +354,7 @@ int main(int argc, char ** argv) {
 			assert(db_entry != NULL);
 
 			const char * filepath = mtree_entry_get_filepath(db_entry);
-			if(strcmp(filepath, "/.PKGINFO") == 0 || strcmp(filepath, "/.INSTALL") == 0 || strcmp(filepath, "/.CHANGELOG") == 0)
+			if(string_vector_contains(skip, filepath))
 				continue;
 
 			struct filesystem_entry_t * fs_entry = filesystem_get_path(filesystem, filepath);

--- a/src/string.c
+++ b/src/string.c
@@ -64,3 +64,11 @@ void convert_octal(char * str) {
 	}
 	*dest = 0;
 }
+
+
+bool string_vector_contains(const char * const * vector, const char * str) {
+	for(const char * const * it = vector; *it != NULL; it++)
+		if(strcmp(*it, str) == 0)
+			return true;
+	return false;
+}

--- a/src/string.h
+++ b/src/string.h
@@ -4,6 +4,8 @@
 
 #include "list.h"
 
+#include <stdbool.h>
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -29,6 +31,10 @@ alpm_list_t * split_words(const char * str);
  */
 void convert_octal(char * str);
 
+/**
+ * Searches the vector for the given string. Returns true if and only if the string is found.
+ */
+bool string_vector_contains(const char * const * vector, const char * str);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Refactor skipping over files into a function that iterates over a string vector. New files to skip
over can be added simply by adding them to `skip` in src/main.c

Fixes #2
